### PR TITLE
Improvements to generics.

### DIFF
--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -145,15 +145,25 @@ private:
 class GenericDetails {
 public:
   using listType = std::list<const Symbol *>;
+  GenericDetails() {}
+  GenericDetails(const listType &specificProcs);
+  GenericDetails(Symbol &&specific) { set_specific(std::move(specific)); }
 
   const listType specificProcs() const { return specificProcs_; }
+  void add_specificProc(const Symbol *proc) { specificProcs_.push_back(proc); }
 
-  void add_specificProc(const Symbol *proc) {
-    specificProcs_.push_back(proc);
-  }
+  std::unique_ptr<Symbol> &specific() { return specific_; }
+  void set_specific(Symbol &&specific);
+
+  // Check that specific is one of the specificProcs. If not, return the
+  // specific as a raw pointer.
+  const Symbol *CheckSpecific() const;
 
 private:
+  // all of the specific procedures for this generic
   listType specificProcs_;
+  // a specific procedure with the same name as this generic, if any
+  std::unique_ptr<Symbol> specific_;
 };
 
 class UnknownDetails {};
@@ -210,6 +220,7 @@ public:
   void add_occurrence(const SourceName &name) { occurrences_.push_back(name); }
 
   // Follow use-associations to get the ultimate entity.
+  Symbol &GetUltimate();
   const Symbol &GetUltimate() const;
 
   bool isSubprogram() const;

--- a/test/semantics/resolve17.f90
+++ b/test/semantics/resolve17.f90
@@ -1,0 +1,17 @@
+module m
+  integer :: foo
+  !Note: PGI, Intel, and GNU allow this; NAG and Sun do not
+  !ERROR: 'foo' is already declared in this scoping unit
+  interface foo
+  end interface
+end module
+
+module m2
+  !Note: PGI and GNU allow this; Intel, NAG, and Sun do not
+  !ERROR: 's' is already declared in this scoping unit
+  interface s
+  end interface
+contains
+  subroutine s
+  end subroutine
+end module

--- a/test/semantics/resolve18.f90
+++ b/test/semantics/resolve18.f90
@@ -1,0 +1,21 @@
+module m1
+  implicit none
+contains
+  subroutine foo(x)
+    real :: x
+  end subroutine
+end module
+
+!Note: PGI, Intel, GNU, and NAG allow this; Sun does not
+module m2
+  use m1
+  implicit none
+  !ERROR: 'foo' is already declared in this scoping unit
+  interface foo
+    module procedure s
+  end interface
+contains
+  subroutine s(i)
+    integer :: i
+  end subroutine
+end module

--- a/test/semantics/resolve19.f90
+++ b/test/semantics/resolve19.f90
@@ -1,0 +1,23 @@
+module m
+  interface a
+    subroutine s(x)
+      real :: x
+    end subroutine
+    !ERROR: 's' is already declared in this scoping unit
+    subroutine s(x)
+      integer :: x
+    end subroutine
+  end interface
+end module
+
+module m2
+  interface s
+    subroutine s(x)
+      real :: x
+    end subroutine
+    !ERROR: 's' is already declared in this scoping unit
+    subroutine s(x)
+      integer :: x
+    end subroutine
+  end interface
+end module


### PR DESCRIPTION
When a generic or specific procedure is use-associated, make a copy of
it in the current scope (replacing the symbol that has `UseDetails`) so
that we can make changes to it. This permits a generic to be defined in
one module and extended with more specific procedures in another.

When a specific procedure has the same name as its generic, it can't be
stored directly in the scope because that is indexed by name and the
generic is already there. So instead we store the specific in the
`GenericDetails` of the generic symbol.

Enforce the rule that a generic and a procedure can only have the same
name if the procedure is one of the specifics of the generic.

Refactorings done is support of this change:
- Add `FindSymbol()` and `EraseSymbol()` as helpers to find or erase a
  symbol in the current scope. Make use of `FindSymbol()` where appropriate.
- Add `SayAlreadyDeclared()` to report a common error.