### PR TITLE
Process procedure declarations and derived types.

### DIFF
--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -45,7 +45,7 @@ void ObjectEntityDetails::set_shape(const ArraySpec &shape) {
 
 ProcEntityDetails::ProcEntityDetails(const EntityDetails &d) {
   if (auto &type = d.type()) {
-    interface_ = *type;
+    interface_.set_type(*type);
   }
 }
 

--- a/lib/semantics/type.cc
+++ b/lib/semantics/type.cc
@@ -268,6 +268,27 @@ std::ostream &operator<<(std::ostream &o, const DeclTypeSpec &x) {
   }
 }
 
+ProcInterface::ProcInterface(const ProcInterface &that)
+  : symbol_{that.symbol_} {
+  if (that.type_) {
+    set_type(*that.type_);
+  }
+}
+ProcInterface &ProcInterface::operator=(ProcInterface &&that) {
+  symbol_ = that.symbol_;
+  type_ = std::move(that.type_);
+  return *this;
+}
+
+void ProcInterface::set_symbol(const Symbol &symbol) {
+  CHECK(!type_);
+  symbol_ = &symbol;
+}
+void ProcInterface::set_type(const DeclTypeSpec &type) {
+  CHECK(!symbol_);
+  type_ = std::make_unique<DeclTypeSpec>(type);
+}
+
 std::ostream &operator<<(std::ostream &o, const ProcDecl &x) {
   return o << x.name_.ToString();
 }

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -386,30 +386,12 @@ class Symbol;
 class ProcInterface {
 public:
   ProcInterface() = default;
-  ProcInterface(ProcInterface &&that)
-    : symbol_{that.symbol_}, type_{std::move(that.type_)} {}
-  ProcInterface(const ProcInterface &that) : symbol_{that.symbol_} {
-    if (that.type_) {
-      *this = *that.type_;
-    }
-  }
-  ProcInterface &operator=(ProcInterface &&that) {
-    symbol_ = that.symbol_;
-    type_ = std::move(that.type_);
-    return *this;
-  }
-  ProcInterface &operator=(const Symbol &symbol) {
-    CHECK(!type_);
-    symbol_ = &symbol;
-    return *this;
-  }
-  ProcInterface &operator=(const DeclTypeSpec &type) {
-    CHECK(!symbol_);
-    type_ = std::make_unique<DeclTypeSpec>(type);
-    return *this;
-  }
+  ProcInterface(const ProcInterface &);
+  ProcInterface &operator=(ProcInterface &&);
   const Symbol *symbol() const { return symbol_; }
   const DeclTypeSpec *type() const { return type_.get(); }
+  void set_symbol(const Symbol &symbol);
+  void set_type(const DeclTypeSpec &type);
 
 private:
   const Symbol *symbol_{nullptr};

--- a/test/semantics/resolve09.f90
+++ b/test/semantics/resolve09.f90
@@ -13,7 +13,26 @@
 ! limitations under the License.
 
 integer :: y
-call x
-!ERROR: Use of 'y' as a procedure conflicts with its declaration
+procedure() :: a
+procedure(real) :: b
+call a  ! OK - can be function or subroutine
+!ERROR: Cannot call subroutine 'a' like a function
+c = a()
+!ERROR: Cannot call function 'b' like a subroutine
+call b
+!ERROR: Cannot call function 'y' like a subroutine
 call y
+call x
+!ERROR: Cannot call subroutine 'x' like a function
+z = x()
+end
+
+subroutine s
+  !ERROR: Cannot call function 'f' like a subroutine
+  call f
+  !ERROR: Cannot call subroutine 's' like a function
+  i = s()
+contains
+  function f()
+  end
 end

--- a/test/semantics/resolve12.f90
+++ b/test/semantics/resolve12.f90
@@ -1,3 +1,17 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
 module m1
 end
 

--- a/test/semantics/resolve13.f90
+++ b/test/semantics/resolve13.f90
@@ -1,3 +1,17 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
 module m1
   integer :: x
   integer, private :: y

--- a/test/semantics/resolve14.f90
+++ b/test/semantics/resolve14.f90
@@ -1,3 +1,17 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
 module m1
   integer :: x
   integer :: y

--- a/test/semantics/resolve15.f90
+++ b/test/semantics/resolve15.f90
@@ -1,3 +1,17 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
 module m
   real :: var
   interface i

--- a/test/semantics/resolve16.f90
+++ b/test/semantics/resolve16.f90
@@ -1,3 +1,17 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
 module m
   interface
     subroutine sub0

--- a/test/semantics/resolve17.f90
+++ b/test/semantics/resolve17.f90
@@ -1,3 +1,17 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
 module m
   integer :: foo
   !Note: PGI, Intel, and GNU allow this; NAG and Sun do not

--- a/test/semantics/resolve18.f90
+++ b/test/semantics/resolve18.f90
@@ -1,3 +1,17 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
 module m1
   implicit none
 contains

--- a/test/semantics/resolve19.f90
+++ b/test/semantics/resolve19.f90
@@ -1,3 +1,17 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
 module m
   interface a
     subroutine s(x)

--- a/test/semantics/resolve20.f90
+++ b/test/semantics/resolve20.f90
@@ -1,0 +1,45 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+module m
+  abstract interface
+    subroutine foo
+    end subroutine
+  end interface
+
+  procedure() :: a
+  procedure(integer) :: b
+  procedure(foo) :: c
+  procedure(bar) :: d
+  !ERROR: Explicit interface 'missing' not found
+  procedure(missing) :: e
+  !ERROR: 'b' is not an abstract interface or a procedure with an explicit interface
+  procedure(b) :: f
+  procedure(c) :: g
+  external :: h
+  !ERROR: 'h' is not an abstract interface or a procedure with an explicit interface
+  procedure(h) :: i
+
+  external :: a, b, c, d
+  !ERROR: EXTERNAL attribute not allowed on 'm'
+  external :: m
+  !ERROR: EXTERNAL attribute not allowed on 'foo'
+  external :: foo
+  !ERROR: EXTERNAL attribute not allowed on 'bar'
+  external :: bar
+
+contains
+  subroutine bar
+  end subroutine
+end module


### PR DESCRIPTION
Add ObjectEntityDetails and ProcEntityDetails to distinguish between an entity
from an object-decl and one from a proc-decl. When we don't know, it stays as
EntityDetails until it is resolved. DeclareEntity in DeclarationVisitor creates
this kind of symbol.

Add flags to Symbol as a convenient place for boolean flags common to many
kinds of symbols. Use it to mark symbols known to be functions or subroutines
so that we can report errors when they are used incorrectly. Improve handling
of EXTERNAL statement.

Handle ProcDecl nodes and add symbols for them.

Partial processing of derived types. Data component declarations are processed
and added to the derived type. Define TypeBoundProc and TypeBoundGeneric in
type.h. Procedure components, type-bound procedures, etc. are not handled yet
and nothing is done with the derived type once it is created. Eliminate
DerivedTypeDefBuilder in favor of just setting fields in derivedTypeData_.

Add GetDeclTypeSpec to go with BeginDeclTypeSpec and EndDeclTypeSpec,
to avoid directly access the private variable.

Add tests in resolve20.f90 for errors related to procedure declarations.
Add missing copyrights to other tests.