### PR TITLE
Remove extraneous Pre/Post for ProcedureDeclarationStmt

### DIFF
--- a/lib/semantics/resolve-names.cc
+++ b/lib/semantics/resolve-names.cc
@@ -142,8 +142,6 @@ public:
   void Post(const parser::AllocateStmt &);
   bool Pre(const parser::TypeGuardStmt &);
   void Post(const parser::TypeGuardStmt &);
-  bool Pre(const parser::ProcedureDeclarationStmt &);
-  void Post(const parser::ProcedureDeclarationStmt &);
 
 protected:
   std::unique_ptr<DeclTypeSpec> &GetDeclTypeSpec();
@@ -780,15 +778,6 @@ bool DeclTypeSpecVisitor::Pre(const parser::TypeGuardStmt &) {
   return true;
 }
 void DeclTypeSpecVisitor::Post(const parser::TypeGuardStmt &) {
-  // TODO: TypeGuardStmt
-  EndDeclTypeSpec();
-  derivedTypeSpec_.reset();
-}
-bool DeclTypeSpecVisitor::Pre(const parser::ProcedureDeclarationStmt &) {
-  BeginDeclTypeSpec();
-  return true;
-}
-void DeclTypeSpecVisitor::Post(const parser::ProcedureDeclarationStmt &) {
   // TODO: TypeGuardStmt
   EndDeclTypeSpec();
   derivedTypeSpec_.reset();


### PR DESCRIPTION
clang give a compilation error on resolve-names.cc because there are
two overloadings of Pre(ProcedureDeclarationStmt) available in
ResolveNamesVisitor. One is defined in DeclTypeSpecVisitor and the other
in DeclarationVisitor. They are both brought in to ResolveNamesVisitor
via `using` statements.

The one in DeclarationVisitor is the one that is supposed to be called.
The other should have been removed when this one was added. This is the
one that gcc chooses to call, so this doesn't change any behavior.

The same applies to the Post method as well.