### PR TITLE
Add name resolution tests

### DIFF
--- a/test/CMakeLists.txt
+++ b/test/CMakeLists.txt
@@ -13,3 +13,4 @@
 # limitations under the License.
 
 add_subdirectory(evaluate)
+add_subdirectory(semantics)

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -1,0 +1,50 @@
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Run tests with test_errors.sh. It compiles the test with f18 and compares
+# actual errors produced with expected ones listed in the source.
+
+set(TESTS
+  implicit01.f90
+  implicit02.f90
+  implicit03.f90
+  implicit04.f90
+  implicit05.f90
+  implicit06.f90
+  implicit07.f90
+  resolve01.f90
+  resolve02.f90
+  resolve03.f90
+  resolve04.f90
+  resolve05.f90
+  resolve06.f90
+  resolve07.f90
+  resolve08.f90
+  resolve09.f90
+  resolve10.f90
+  resolve11.f90
+  resolve12.f90
+  resolve13.f90
+  resolve14.f90
+  resolve15.f90
+  resolve16.f90
+  resolve17.f90
+  resolve18.f90
+  resolve19.f90
+  resolve20.f90
+)
+
+foreach(test ${TESTS})
+  add_test(NAME ${test} COMMAND ${CMAKE_CURRENT_SOURCE_DIR}/test_errors.sh ${test})
+endforeach()

--- a/test/semantics/resolve15.f90
+++ b/test/semantics/resolve15.f90
@@ -16,8 +16,9 @@ module m
   real :: var
   interface i
     !ERROR: 'var' is not a subprogram
+    procedure :: sub, var
     !ERROR: Procedure 'bad' not found
-    procedure :: sub, var, bad
+    procedure :: bad
   end interface
 contains
   subroutine sub

--- a/test/semantics/test_errors.sh
+++ b/test/semantics/test_errors.sh
@@ -1,0 +1,46 @@
+#!/usr/bin/bash
+# Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+# Compile a source file and check errors against those listed in the file.
+
+PATH=/usr/bin
+srcdir=$(dirname $0)
+src=$srcdir/$1
+[[ ! -f $src ]] && echo "File not found: $src" && exit 1
+temp=$(mktemp --directory --tmpdir=.)
+trap "rm -rf $temp" EXIT
+log=$temp/log
+actual=$temp/actual
+expect=$temp/expect
+diffs=$temp/diffs
+
+cmd="../../tools/f18/f18 -fdebug-resolve-names -fparse-only $src"
+$cmd > $log 2>&1
+
+# $actual has errors from the compiler; $expect has them from !ERROR comments in source
+# Format both as "<line>: <text>" so they can be diffed.
+sed -n 's=^[^:]*:\([^:]*\):[^:]*: error: =\1: =p' $log > $actual
+{ echo; cat $src; } | cat -n | sed -n 's=^ *\([0-9]*\)\t *\!ERROR: *=\1: =p' > $expect
+
+if diff -U0 $actual $expect > $diffs; then
+  echo PASS
+else
+  echo "$cmd"
+  < $diffs \
+    sed -n -e 's/^-\([0-9]\)/expect at \1/p' -e 's/^+\([0-9]\)/actual at \1/p' \
+    | sort -n -k 2
+  echo FAIL
+  exit 1
+fi


### PR DESCRIPTION
The Fortran source files in test/semantics all contain expected
errors in comments. The script `test_errors.sh` compiles a file with
`f18 -fdebug-resolve-names -fparse-only` and compares the actual
errors produced against the expected ones.

The change to `resolve15.f90` is necessary because `test_errors.sh` can't
handle two expected errors for the same source line.

A useful command to run these is `ctest -R f90 --output-on-failure`.
`-R f90` means only run tests with f90 in the name
`--output-on-failure` prints the output of `test_errors.sh` when a test
fails, showing the expected and actual messages that differ.