### PR TITLE
Change how memory for Symbol instances is managed.

### DIFF
--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -23,7 +23,7 @@
 namespace Fortran::semantics {
 
 // Symbols collected during name resolution that are added to parse tree.
-using symbolMap = std::map<const SourceName, Symbol *>;
+using symbolMap = std::map<const char *, Symbol *>;
 
 /// Walk the parse tree and add symbols from the symbolMap in Name nodes.
 /// Convert mis-identified statement functions to array element assignments.
@@ -37,7 +37,7 @@ public:
 
   // Fill in name.symbol if there is a corresponding symbol
   void Post(parser::Name &name) {
-    const auto it = symbols_.find(name.source);
+    const auto it = symbols_.find(name.source.begin());
     if (it != symbols_.end()) {
       name.symbol = it->second;
     }
@@ -104,9 +104,9 @@ private:
 
 static void CollectSymbols(Scope &scope, symbolMap &symbols) {
   for (auto &pair : scope) {
-    Symbol &symbol{pair.second};
-    for (const auto &name : symbol.occurrences()) {
-      symbols.emplace(name, &symbol);
+    Symbol *symbol{pair.second};
+    for (const auto &name : symbol->occurrences()) {
+      symbols.emplace(name.begin(), symbol);
     }
   }
   for (auto &child : scope.children()) {

--- a/lib/semantics/scope.cc
+++ b/lib/semantics/scope.cc
@@ -22,6 +22,8 @@ const Scope Scope::systemScope{
     Scope::systemScope, Scope::Kind::System, nullptr};
 Scope Scope::globalScope{Scope::systemScope, Scope::Kind::Global, nullptr};
 
+Symbols<1024> Scope::allSymbols;
+
 Scope &Scope::MakeScope(Kind kind, Symbol *symbol) {
   children_.emplace_back(*this, kind, symbol);
   return children_.back();
@@ -34,7 +36,7 @@ std::ostream &operator<<(std::ostream &os, const Scope &scope) {
   }
   os << scope.children_.size() << " children\n";
   for (const auto &sym : scope.symbols_) {
-    os << "  " << sym.second << "\n";
+    os << "  " << *sym.second << "\n";
   }
   return os;
 }

--- a/lib/semantics/symbol.cc
+++ b/lib/semantics/symbol.cc
@@ -60,20 +60,19 @@ GenericDetails::GenericDetails(const listType &specificProcs) {
   }
 }
 
-void GenericDetails::set_specific(Symbol &&specific) {
+void GenericDetails::set_specific(Symbol *specific) {
   CHECK(!specific_);
-  specific_ = std::unique_ptr<Symbol>(new Symbol(std::move(specific)));
+  specific_ = specific;
 }
 
 const Symbol *GenericDetails::CheckSpecific() const {
-  if (const auto *specific = specific_.get()) {
+  if (specific_) {
     for (const auto *proc : specificProcs_) {
-      if (proc == specific) {
+      if (proc == specific_) {
         return nullptr;
       }
     }
-    std::cerr << "specific: " << *specific << "\n";
-    return specific;
+    return specific_;
   } else {
     return nullptr;
   }


### PR DESCRIPTION
With this change, all instances `Symbol` are stored in `class Symbols`.
`Scope.symbols_`, which used to own the symbol memory, now maps names to
`Symbol*` instead. This causes a bunch of reference-to-pointer changes
because of the change in type of key-value pairs. It also requires a
default constructor for `Symbol`, which means `owner_` can't be a reference.

`Symbols` manages `Symbol` instances by allocating a block of them at a time
and returning the next one when needed. They are never freed.

The reason for the change is that there are a few cases where we need
to have a two symbols with the same name, so they can't both live in
the map in `Scope`. Those are:
1. When there is an erroneous re-declaration of a name we may delete the
   first symbol and replace it with a new one. If we have saved a pointer
   to the first one it is now dangling. This can be seen by running
   `f18 -fdebug-dump-symbols -fparse-only test/semantics/resolve19.f90`
   under valgrind. Subroutine s is declared twice: each results in a
   scope that contains a pointer back to the symbol for the subroutine.
   After the second symbol for s is created the first is gone so the
   pointer in the scope is invalid.
2. A generic and one of its specifics can have the same name. We currently
   handle that by moving the symbol for the specific into a `unique_ptr`
   in the generic. So in that case the symbol is owned by another symbol
   instead of by the scope. It is simpler if we only have to deal with
   moving the raw pointer around.
3. A generic and a derived type can have the same name. This case isn't
   handled yet, but it can be done like no. 2 above. It's more complicated
   because the derived type and the generic can be declared in either
   order.