### PR TITLE
Name resolution for derived types.

### DIFF
--- a/lib/semantics/rewrite-parse-tree.cc
+++ b/lib/semantics/rewrite-parse-tree.cc
@@ -102,11 +102,20 @@ private:
   }
 };
 
+static void CollectSymbol(Symbol &symbol, symbolMap &symbols) {
+  for (const auto &name : symbol.occurrences()) {
+    symbols.emplace(name.begin(), &symbol);
+  }
+}
+
 static void CollectSymbols(Scope &scope, symbolMap &symbols) {
   for (auto &pair : scope) {
     Symbol *symbol{pair.second};
-    for (const auto &name : symbol->occurrences()) {
-      symbols.emplace(name.begin(), symbol);
+    CollectSymbol(*symbol, symbols);
+    if (auto *details = symbol->detailsIf<GenericDetails>()) {
+      if (details->derivedType()) {
+        CollectSymbol(*details->derivedType(), symbols);
+      }
     }
   }
   for (auto &child : scope.children()) {

--- a/test/semantics/CMakeLists.txt
+++ b/test/semantics/CMakeLists.txt
@@ -43,6 +43,9 @@ set(TESTS
   resolve18.f90
   resolve19.f90
   resolve20.f90
+  resolve21.f90
+  resolve22.f90
+  resolve23.f90
 )
 
 foreach(test ${TESTS})

--- a/test/semantics/resolve21.f90
+++ b/test/semantics/resolve21.f90
@@ -1,0 +1,50 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+subroutine s1
+  type :: t
+    integer :: i
+    integer :: s1
+    integer :: t
+  end type
+  !ERROR: 't' is already declared in this scoping unit
+  integer :: t
+  integer :: i, j
+  type(t) :: x
+  !ERROR: Derived type 't2' not found
+  type(t2) :: y
+  !ERROR: 'z' is not an object of derived type; it is implicitly typed
+  i = z%i
+  !ERROR: 's1' is not an object of derived type
+  i = s1%i
+  !ERROR: 'j' is not an object of derived type
+  i = j%i
+  !ERROR: Component 'j' not found in derived type 't'
+  i = x%j
+  i = x%i  !OK
+end subroutine
+
+subroutine s2
+  type :: t1
+    integer :: i
+  end type
+  type :: t2
+    type(t1) :: x
+  end type
+  type(t2) :: y
+  integer :: i
+  !ERROR: Component 'j' not found in derived type 't1'
+  k = y%x%j
+  k = y%x%i !OK
+end subroutine

--- a/test/semantics/resolve22.f90
+++ b/test/semantics/resolve22.f90
@@ -1,0 +1,45 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+subroutine s1
+  !OK: interface followed by type with same name
+  interface t
+  end interface
+  type t
+  end type
+  type(t) :: x
+  x = t()
+end subroutine
+
+subroutine s2
+  !OK: type followed by interface with same name
+  type t
+  end type
+  interface t
+  end interface
+  type(t) :: x
+  x = t()
+end subroutine
+
+subroutine s3
+  type t
+  end type
+  interface t
+  end interface
+  !ERROR: 't' is already declared in this scoping unit
+  type t
+  end type
+  type(t) :: x
+  x = t()
+end subroutine

--- a/test/semantics/resolve23.f90
+++ b/test/semantics/resolve23.f90
@@ -1,0 +1,26 @@
+! Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+!
+! Licensed under the Apache License, Version 2.0 (the "License");
+! you may not use this file except in compliance with the License.
+! You may obtain a copy of the License at
+!
+!     http://www.apache.org/licenses/LICENSE-2.0
+!
+! Unless required by applicable law or agreed to in writing, software
+! distributed under the License is distributed on an "AS IS" BASIS,
+! WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+! See the License for the specific language governing permissions and
+! limitations under the License.
+
+module m
+  type :: t
+    real :: y
+  end type
+end module
+
+use m
+implicit type(t)(x)
+z = x%y  !OK: x is type(t)
+!ERROR: 'w' is not an object of derived type; it is implicitly typed
+z = w%y
+end

--- a/tools/f18/dump.cc
+++ b/tools/f18/dump.cc
@@ -26,7 +26,9 @@
   std::ostream &operator<<(std::ostream &, const name &); \
   } \
   void Dump(std::ostream &os, const ns::name &x) { os << x << '\n'; } \
-  void Dump(std::ostream &os, const ns::name *x) { Dump(os, *x); } \
+  void Dump(std::ostream &os, const ns::name *x) { \
+    if (x == nullptr) os << "null\n"; else Dump(os, *x); \
+  } \
   void Dump(const ns::name &x) { Dump(std::cerr, x); } \
   void Dump(const ns::name *x) { Dump(std::cerr, *x); }
 
@@ -35,6 +37,7 @@ DEFINE_DUMP(parser, Name)
 DEFINE_DUMP(parser, CharBlock)
 DEFINE_DUMP(semantics, Symbol)
 DEFINE_DUMP(semantics, Scope)
+DEFINE_DUMP(semantics, TypeSpec)
 DEFINE_DUMP(semantics, DeclTypeSpec)
 }  // namespace Fortran
 


### PR DESCRIPTION
This consists of:
- a new kind of symbols to represent them with `DerivedTypeDetails`
- creating symbols for derived types when they are declared
- creating a new kind of scope for the type to hold component symbols
- resolving entity declarations of objects of derived type
- resolving references to objects of derived type and to components
- handling derived types with same name as generic

Type parameters are not yet implemented.

Refactor `DeclTypeSpec` to be a value class wrapping an IntrinsicTypeSpec
or a `DerivedTypeSpec` (or neither in the `TypeStar` and `ClassStar` cases).
Store `DerivedTypeSpec` objects in a new structure the current scope
using `MakeDerivedTypeSpec` so that `DeclTypeSpec` can just contain a pointer to
them, as it currently does for intrinsic types.

In `GenericDetails`, add `derivedType` field to handle case where generic
and derived type have the same name. The generic is in the scope and the
derived type is referenced from the generic, similar to the case where a
generic and specific have the same name. When one of these names is
mis-recognized, we sometimes have to fix up the 'occurrences' lists
of the symbols.

Assign implicit types as soon as an entity is encountered that requires
one. Otherwise implicit derived types won't work. When we see `x%y` we
have to know the type of `x` in order to resolve `y`. Add `Implicit` flag
to mark symbols that were implicitly typed

For symbols that introduce a new scope, include a pointer back to that
scope.

Add `CurrNonTypeScope()` for the times when we want the current scope but
ignoring derived type scopes. For example, that happens when looking for
types or parameters, or creating implicit symbols.
