### PR TITLE
Fix problems in PR 109 when compiling with clang.

### DIFF
--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -295,7 +295,7 @@ private:
   const std::string GetDetailsName() const;
   friend std::ostream &operator<<(std::ostream &, const Symbol &);
   template<std::size_t> friend class Symbols;
-  template<class, std::size_t> friend class std::array;
+  template<class, std::size_t> friend struct std::array;
 };
 
 std::ostream &operator<<(std::ostream &, Symbol::Flag);

--- a/lib/semantics/type.h
+++ b/lib/semantics/type.h
@@ -566,6 +566,7 @@ public:
   std::ostream &Output(std::ostream &o) const override { return o << *this; }
   explicit DerivedTypeSpec(const SourceName &name) : name_{&name} {}
   DerivedTypeSpec() = delete;
+  virtual ~DerivedTypeSpec() {}
   const SourceName &name() const { return *name_; }
   const Scope *scope() const { return scope_; }
   void set_scope(const Scope &);


### PR DESCRIPTION
This gets the code base back to compiling cleanly with clang after
pull request 109.

There were two overloadings of `Post(const parser::DeclarationTypeSpec::Type &)`.
The one in DeclarationVisitor needed to call the one in DeclTypeSpecVisitor.
This was fixed by introducing a new function, SetDerivedDeclTypeSpec, to do
the equivalent thing.