### PR TITLE
Support unparse with symbol annotations.

### DIFF
--- a/lib/semantics/CMakeLists.txt
+++ b/lib/semantics/CMakeLists.txt
@@ -20,6 +20,7 @@ add_library(FlangSemantics
   scope.cc
   symbol.cc
   type.cc
+  unparse-with-symbols.cc
 )
 
 target_link_libraries(FlangSemantics

--- a/lib/semantics/symbol.h
+++ b/lib/semantics/symbol.h
@@ -277,6 +277,9 @@ public:
   Symbol &GetUltimate();
   const Symbol &GetUltimate() const;
 
+  const DeclTypeSpec *GetType() const;
+  void SetType(const DeclTypeSpec &);
+
   bool isSubprogram() const;
   bool HasExplicitInterface() const;
 
@@ -294,6 +297,7 @@ private:
   Symbol() {}  // only created in class Symbols
   const std::string GetDetailsName() const;
   friend std::ostream &operator<<(std::ostream &, const Symbol &);
+  friend std::ostream &DumpForUnparse(std::ostream &, const Symbol &, bool);
   template<std::size_t> friend class Symbols;
   template<class, std::size_t> friend struct std::array;
 };

--- a/lib/semantics/unparse-with-symbols.cc
+++ b/lib/semantics/unparse-with-symbols.cc
@@ -1,0 +1,154 @@
+// Copyright (c) 2018, NVIDIA CORPORATION.  All rights reserved.
+//
+// Licensed under the Apache License, Version 2.0 (the "License");
+// you may not use this file except in compliance with the License.
+// You may obtain a copy of the License at
+//
+//     http://www.apache.org/licenses/LICENSE-2.0
+//
+// Unless required by applicable law or agreed to in writing, software
+// distributed under the License is distributed on an "AS IS" BASIS,
+// WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+// See the License for the specific language governing permissions and
+// limitations under the License.
+
+#include "unparse-with-symbols.h"
+#include "symbol.h"
+#include "../parser/parse-tree-visitor.h"
+#include "../parser/parse-tree.h"
+#include "../parser/unparse.h"
+#include <map>
+#include <ostream>
+#include <set>
+
+namespace Fortran::semantics {
+
+// Walk the parse tree and collection information about which statements
+// define and reference symbols. Then PrintSymbols outputs information
+// by statement.
+class SymbolDumpVisitor {
+public:
+  // Write out symbols defined or referenced at this statement.
+  void PrintSymbols(const parser::CharBlock &stmt, std::ostream &, int) const;
+
+  template<typename T> bool Pre(const T &) { return true; }
+  template<typename T> void Post(const T &) {}
+  template<typename T> bool Pre(const parser::Statement<T> &stmt) {
+    currStmt_ = &stmt.source;
+    return true;
+  }
+  template<typename T> void Post(const parser::Statement<T> &) {
+    currStmt_ = nullptr;
+  }
+  void Post(const parser::Name &);
+  void Post(const parser::EndFunctionStmt &) { EndScope(); }
+  void Post(const parser::EndModuleStmt &) { EndScope(); }
+  void Post(const parser::EndMpSubprogramStmt &) { EndScope(); }
+  void Post(const parser::EndProgramStmt &) { EndScope(); }
+  void Post(const parser::EndSubmoduleStmt &) { EndScope(); }
+  void Post(const parser::EndSubroutineStmt &) { EndScope(); }
+  bool Pre(const parser::DataRef &) { return PreReference(); }
+  void Post(const parser::DataRef &) { PostReference(); }
+  bool Pre(const parser::Designator &) { return PreReference(); }
+  void Post(const parser::Designator &) { PostReference(); }
+  bool Pre(const parser::StructureComponent &) { return PreReference(); }
+  void Post(const parser::StructureComponent &) { PostReference(); }
+  bool Pre(const parser::ProcedureDesignator &) { return PreReference(); }
+  void Post(const parser::ProcedureDesignator &) { PostReference(); }
+  bool Pre(const parser::DerivedTypeSpec &) { return PreReference(); }
+  void Post(const parser::DerivedTypeSpec &) { PostReference(); }
+  bool Pre(const parser::UseStmt &) { return PreReference(); }
+  void Post(const parser::UseStmt &) { PostReference(); }
+
+private:
+  using symbolMap = std::multimap<const char *, const Symbol *>;
+
+  const SourceName *currStmt_{nullptr};  // current statement we are processing
+  int isRef_{0};  // > 0 means in the context of a reference
+  symbolMap defs_;  // statement location to symbol defined there
+  symbolMap refs_;  // statement location to symbol referenced there
+  std::map<const Symbol *, const char *> symbolToStmt_;  // symbol to def
+
+  void EndScope();
+  bool PreReference();
+  void PostReference();
+  bool isRef() const { return isRef_ > 0; }
+  void PrintSymbols(const parser::CharBlock &, std::ostream &, int,
+      const symbolMap &, bool) const;
+  void Indent(std::ostream &, int) const;
+};
+
+void SymbolDumpVisitor::PrintSymbols(
+    const parser::CharBlock &location, std::ostream &out, int indent) const {
+  PrintSymbols(location, out, indent, defs_, true);
+  PrintSymbols(location, out, indent, refs_, false);
+}
+void SymbolDumpVisitor::PrintSymbols(const parser::CharBlock &location,
+    std::ostream &out, int indent, const symbolMap &symbols, bool isDef) const {
+  std::set<const Symbol *> done;  // used to prevent duplicates
+  auto range{symbols.equal_range(location.begin())};
+  for (auto it{range.first}; it != range.second; ++it) {
+    auto *symbol{it->second};
+    if (done.insert(symbol).second) {
+      Indent(out, indent);
+      out << '!' << (isDef ? "DEF"s : "REF"s) << ": ";
+      DumpForUnparse(out, symbol->GetUltimate(), isDef);
+      out << '\n';
+    }
+  }
+}
+void SymbolDumpVisitor::Indent(std::ostream &out, int indent) const {
+  for (int i{0}; i < indent; ++i) {
+    out << ' ';
+  }
+}
+
+void SymbolDumpVisitor::Post(const parser::Name &name) {
+  if (const auto *symbol{name.symbol}) {
+    CHECK(currStmt_);
+    // If this is the first reference to an implicitly defined symbol,
+    // record it as a def.
+    bool isImplicit{symbol->test(Symbol::Flag::Implicit) &&
+        symbolToStmt_.find(symbol) == symbolToStmt_.end()};
+    if (isRef() && !isImplicit) {
+      refs_.emplace(currStmt_->begin(), symbol);
+    } else {
+      symbolToStmt_.emplace(symbol, currStmt_->begin());
+    }
+  }
+}
+
+// Defs are initially saved in symbolToStmt_ so that a symbol defined across
+// multiple statements is associated with only one (the first). Now that we
+// are at the end of a scope, move them into defs_.
+void SymbolDumpVisitor::EndScope() {
+  for (auto pair : symbolToStmt_) {
+    defs_.emplace(pair.second, pair.first);
+  }
+  symbolToStmt_.clear();
+}
+
+// {Pre,Post}Reference() are called around constructs that contains symbols
+// references. Sometimes those are nested (e.g. DataRef inside Designator)
+// so we need to maintain a count to know when we are back out.
+bool SymbolDumpVisitor::PreReference() {
+  ++isRef_;
+  return true;
+}
+void SymbolDumpVisitor::PostReference() {
+  CHECK(isRef_ > 0);
+  --isRef_;
+}
+
+void UnparseWithSymbols(std::ostream &out, const parser::Program &program,
+    parser::Encoding encoding) {
+  SymbolDumpVisitor visitor;
+  parser::Walk(program, visitor);
+  parser::preStatementType preStatement{
+      [&](const parser::CharBlock &location, std::ostream &out, int indent) {
+        visitor.PrintSymbols(location, out, indent);
+      }};
+  parser::Unparse(out, program, encoding, false, &preStatement);
+}
+
+}  // namespace Fortran::semantics

--- a/lib/semantics/unparse-with-symbols.h
+++ b/lib/semantics/unparse-with-symbols.h
@@ -12,27 +12,19 @@
 // See the License for the specific language governing permissions and
 // limitations under the License.
 
-#ifndef FORTRAN_PARSER_UNPARSE_H_
-#define FORTRAN_PARSER_UNPARSE_H_
+#ifndef FORTRAN_SEMANTICS_UNPARSE_WITH_SYMBOLS_H_
+#define FORTRAN_SEMANTICS_UNPARSE_WITH_SYMBOLS_H_
 
-#include "char-block.h"
-#include "characters.h"
-#include <functional>
+#include "../parser/characters.h"
 #include <iosfwd>
 
 namespace Fortran::parser {
-
 struct Program;
-
-// A function called before each Statement is unparsed.
-using preStatementType =
-    std::function<void(const CharBlock &, std::ostream &, int)>;
-
-/// Convert parsed program to out as Fortran.
-void Unparse(std::ostream &out, const Program &program,
-    Encoding encoding = Encoding::UTF8, bool capitalizeKeywords = true,
-    preStatementType *preStatement = nullptr);
-
 }  // namespace Fortran::parser
 
-#endif
+namespace Fortran::semantics {
+void UnparseWithSymbols(std::ostream &, const parser::Program &,
+    parser::Encoding encoding = parser::Encoding::UTF8);
+}  // namespace Fortran::semantics
+
+#endif  // FORTRAN_SEMANTICS_UNPARSE_WITH_SYMBOLS_H_

--- a/tools/f18/f18.cc
+++ b/tools/f18/f18.cc
@@ -84,6 +84,7 @@ struct DriverOptions {
   bool dumpProvenance{false};
   bool dumpCookedChars{false};
   bool dumpUnparse{false};
+  bool dumpUnparseWithSymbols{false};
   bool dumpParseTree{false};
   bool dumpSymbols{false};
   bool debugResolveNames{false};
@@ -201,24 +202,24 @@ std::string CompileFortran(
   if (driver.measureTree) {
     MeasureParseTree(parseTree);
   }
-  if (driver.dumpParseTree) {
-    Fortran::semantics::DumpTree(std::cout, parseTree);
-  }
-  if (driver.dumpUnparse) {
-    if (driver.dumpSymbols) {
-      Fortran::semantics::ResolveNames(parseTree, parsing.cooked());
-      Fortran::semantics::UnparseWithSymbols(
-          std::cout, parseTree, driver.encoding);
-    } else {
-      Unparse(std::cout, parseTree, driver.encoding, true);
-    }
-    return {};
-  }
-  if (driver.debugResolveNames || driver.dumpSymbols) {
+  if (driver.debugResolveNames || driver.dumpSymbols ||
+      driver.dumpUnparseWithSymbols) {
     Fortran::semantics::ResolveNames(parseTree, parsing.cooked());
     if (driver.dumpSymbols) {
       Fortran::semantics::DumpSymbols(std::cout);
     }
+    if (driver.dumpUnparseWithSymbols) {
+      Fortran::semantics::UnparseWithSymbols(
+          std::cout, parseTree, driver.encoding);
+      return {};
+    }
+  }
+  if (driver.dumpParseTree) {
+    Fortran::semantics::DumpTree(std::cout, parseTree);
+  }
+  if (driver.dumpUnparse) {
+    Unparse(std::cout, parseTree, driver.encoding, true /*capitalize*/);
+    return {};
   }
   if (driver.parseOnly) {
     return {};
@@ -365,6 +366,8 @@ int main(int argc, char *const argv[]) {
       options.instrumentedParse = true;
     } else if (arg == "-funparse") {
       driver.dumpUnparse = true;
+    } else if (arg == "-funparse-with-symbols") {
+      driver.dumpUnparseWithSymbols = true;
     } else if (arg == "-fparse-only") {
       driver.parseOnly = true;
     } else if (arg == "-c") {
@@ -397,6 +400,7 @@ int main(int argc, char *const argv[]) {
           << "  -fparse-only         parse only, no output except messages\n"
           << "  -funparse            parse & reformat only, no code "
              "generation\n"
+          << "  -funparse-with-symbols  parse, resolve symbols, and unparse\n"
           << "  -fdebug-measure-parse-tree\n"
           << "  -fdebug-dump-provenance\n"
           << "  -fdebug-dump-parse-tree\n"


### PR DESCRIPTION
When `-fdebug-dump-symbols` is supplied with `-funparse`, include symbol
information in comments in the Fortran output. This will be used for
testing to verify that correct symbols are defined and references in
the right place.

In `UnparseWithSymbols()`, walk the parse tree and collect symbol
definitions and references, organized by statement. When a symbol is
defined across several statement it is associated with the first.
The definition of implicitly defined symbols is associated with the
first reference.

To write out the symbol information, a new optional argument is added to
`Unparse()`: it is a function that is called immediately before each
statement is unparsed. We pass in a function that prints out the symbol
information collected for that statement.

Add `Symbol::GetType()` to make it easier to write the symbol types
and add `Symbol::SetType()` for uniformity.

Here is an example. When the following is compiled with `-funparse -fdebug-dump-symbols`
the output is identical to the input (i.e. the comments are stripped out but the
symbol information is added back in during unparsing -- it's not just `cat`).
```
!DEF: /sub Subprogram
!DEF: /sub/y Entity REAL(8)
subroutine sub (y)
 real(kind=8) y
 !DEF: /sub/i ALLOCATABLE, VOLATILE ObjectEntity INTEGER
 allocatable :: i
 !DEF: /sub/j Entity INTEGER
 integer i, j
 volatile :: i
 !DEF: /sub/t DerivedType
 type :: t
  !DEF: /sub/t/i ObjectEntity INTEGER
  integer :: i
 end type
 !DEF: /sub/x Entity TYPE(t)
 !REF: /sub/t
 type(t) :: x
 !REF: /sub/x
 !REF: /sub/t/i
 x%i = 1
 !DEF: /sub/k (implicit) ObjectEntity INTEGER
 !REF: /sub/i
 !REF: /sub/j
 i = j+i+k
end subroutine
```